### PR TITLE
 Add one more solution 'isPalindromePermutationsBit' to ch1-q4, fix issue #3 .

### DIFF
--- a/src/chapter1/ch1-q4.js
+++ b/src/chapter1/ch1-q4.js
@@ -34,7 +34,7 @@ export function isPalindromePermutationsSet(str) {
 }
 
 /**
- * Use a integer which as 32 bits as a series of flags. Convert each coming 
+ * Use a Number in binray form as a series of flags. Convert each coming 
  * letter (English Alphabet) to lowercase and map it to an integer between 0 and 26,
  * see it as the position of bit and toggle this bit. After iteration, check if 
  * flags has at most one bit that is set to 1.
@@ -60,8 +60,7 @@ export function isPalindromePermutationsBit(str) {
     }
   }
 
-  return (((flags - 1) & flags) === 0); // ex: flags should be 32 bits, 
-                                        // abuse 4 bits for brief explanation here.
+  return (((flags - 1) & flags) === 0); // Abuse only 4 bits for brief explanation here.
                                         // flags: 0110,  0110 - 0001 = 0101, 0101 & 0110 = 0100
                                         // flags: 0100,  0100 - 0001 = 0011, 0011 & 0100 = 0000
                                         // flags: 0000,  0 - 1 = -1,         1111 (two's complement) & 0000 = 0000 

--- a/src/chapter1/ch1-q4.js
+++ b/src/chapter1/ch1-q4.js
@@ -20,14 +20,50 @@ export function isPalindromePermutationsSet(str) {
   let chars = new Set();
   for (let char of str) {
     if (char !== ' ') { // ignore spaces
-      if (chars.has(char)) {
-        chars.delete(char);
+      let lchar = char.toLowerCase();
+      if (chars.has(lchar)) {
+        chars.delete(lchar);
       }
       else {
-        chars.add(char);
+        chars.add(lchar);
       }
     }
   }
 
   return chars.size <= 1;
 }
+
+/**
+ * Use a integer which as 32 bits as a series of flags. Convert each coming 
+ * letter (English Alphabet) to lowercase and map it to an integer between 0 and 26,
+ * see it as the position of bit and toggle this bit. After iteration, check if 
+ * flags has at most one bit that is set to 1.
+ *
+ * N = |str|
+ * Time: O(N)
+ * Additional space: O(1)
+ *
+ * @param  {string[]} str String to check as a character array
+ * @return {boolean}      True if input string is a permutation of a palindrome (ignoring spaces), otherwise false
+ */
+
+export function isPalindromePermutationsBit(str) {
+  if (!str) {
+    return false;
+  }
+
+  let flags = 0;
+
+  for (let char of str) {
+    if (char !== ' ') {
+      flags ^= (1 << (char.toLowerCase().charCodeAt(0) - 'a'.charCodeAt(0)));
+    }
+  }
+
+  return (((flags - 1) & flags) === 0); // ex: It should be 32 bits, abuse 4 bits to represent same logic.
+                                        // flags: 0110,  0110 - 0001 = 0101, 0101 & 0110 = 0100
+                                        // flags: 0100,  0100 - 0001 = 0011, 0011 & 0100 = 0000
+                                        // flags: 0000,  0 - 1 = -1,         1111 (two's complement) & 0000 = 0000 
+}
+
+

--- a/src/chapter1/ch1-q4.js
+++ b/src/chapter1/ch1-q4.js
@@ -60,7 +60,8 @@ export function isPalindromePermutationsBit(str) {
     }
   }
 
-  return (((flags - 1) & flags) === 0); // ex: It should be 32 bits, abuse 4 bits to represent same logic.
+  return (((flags - 1) & flags) === 0); // ex: flags should be 32 bits, 
+                                        // abuse 4 bits for brief explanation here.
                                         // flags: 0110,  0110 - 0001 = 0101, 0101 & 0110 = 0100
                                         // flags: 0100,  0100 - 0001 = 0011, 0011 & 0100 = 0000
                                         // flags: 0000,  0 - 1 = -1,         1111 (two's complement) & 0000 = 0000 

--- a/src/chapter1/ch1-q4.spec.js
+++ b/src/chapter1/ch1-q4.spec.js
@@ -18,6 +18,7 @@ for (let key in funcs) {
     [
       ' ',
       '   ',
+      'Tact Coa',
       'aabb',
       'ab a b',
       ' a b a b ',
@@ -25,22 +26,45 @@ for (let key in funcs) {
       'sa sadfgsadfgh jk;hjkz;sadfg hjk;dfghjk;'
     ].forEach(arg => {
 
-      it(`returns true for palindromic string: '${arg}'`, function() {
-        expect(func(arg.split(''))).to.be.true;
-      });
+      if (key === 'isPalindromePermutationsBit') {
+        if(/^[a-zA-Z\s]+$/.test(arg)) {
+          
+          it(`returns true for palindromic string which only contains English alphabet and space: '${arg}'`, function() {
+            expect(func(arg.split(''))).to.be.true;
+          });
 
+        }
+      } else {
+
+        it(`returns true for palindromic string: '${arg}'`, function() {
+          expect(func(arg.split(''))).to.be.true;
+        });
+
+      }
     });
 
     [
       'abcadef',
       '1234567890',
-      'a b'
+      'a b',
+      'sg! sG$'
     ].forEach(arg => {
 
-      it(`returns false for non-palindromic string: '${arg}'`, function() {
-        expect(func(arg.split(''))).to.be.false;
-      });
+      if (key === 'isPalindromePermutationsBit') {
+        if(/^[a-zA-Z\s]+$/.test(arg)) {
+          
+          it(`returns false for palindromic string which only contains English alphabet and space: '${arg}'`, function() {
+            expect(func(arg.split(''))).to.be.false;
+          });
 
+        }
+      } else {
+      
+        it(`returns false for non-palindromic string: '${arg}'`, function() {
+          expect(func(arg.split(''))).to.be.false;
+        });
+
+      }
     });
 
   });


### PR DESCRIPTION
- Add a solution described in CtCI-6th, which use a number as bit vector, toggle the bits. Check that at most one bit is set to 1 subsequently. Space complexity: O(1).
- In this method, we need to assume input string only contains English alphabet and space, so revise the test code to filter the unacceptable inputs to this new method.
![2018-03-04 10 52 27](https://user-images.githubusercontent.com/7093689/36946883-08ef1df0-1fff-11e8-9a58-63dbcdfa736d.png)
- For #3 which @viatsko mentioned, add `.toLowerCase()` to make input which contains uppercase letters available, also add one input for testing in test code.
