### PR TITLE
Fixed return value of the Map version

### DIFF
--- a/src/chapter1/ch1-q2.js
+++ b/src/chapter1/ch1-q2.js
@@ -37,7 +37,7 @@ export function isPermutationMap(str1, str2) {
     }
   }
 
-  return chars.size === 0;
+  return true;
 }
 
 /**


### PR DESCRIPTION
If the for loop finishes without returning false, it will always return true.
Both strings have the same length at this point (if not, the function will return false at its beginning).
So if a character exists in one string and not the other, count will be undefined, and the function will return false.
The function will always return true if it finishes the for loop as the map size will be 0, so might as well return true (could be confusing as to why you have to return the map size).