### PR TITLE
Wrong results.

### DIFF
--- a/src/chapter1/ch1-q6.js
+++ b/src/chapter1/ch1-q6.js
@@ -26,7 +26,7 @@ export function compressString(str) {
     // JS does not have a StringBuilder/StringBuffer style class for creating strings
     // string concatenation has been heavily optimised in JS implementations and
     // is faster than creating a string via an array then using a .join('') at the end
-    cStr += (i - start + 1) + char;
+    cStr += char + (i - start + 1);
   }
 
   return cStr.length < str.length ? cStr : str;


### PR DESCRIPTION
The concatenation of the number with the char should be reversed, ex: "2a" should be "a2"; according the the question prompt.

Implement a method to perform basic string compression using the counts
of repeated characters. For example, the string aabcccccaaa would become a2blc5a3, If the
"compressed" string would not become smaller than the original string, your method should return
the original string. You can assume the string has only uppercase and lowercase letters (a - z).